### PR TITLE
Fix relative paths to Metasploit repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,16 @@ mvn -P deploy package
 ```
 
 to package all the files and copy them into the correct place for Metasploit
-(/data/java). If you get spurious compilation errors, make sure that there
-is an exclude rule in your antivirus for the Metasploit directory (or that
-your antivirus is disabled).
+(`../metasploit-framework/data/java`). If you get spurious compilation errors, 
+make sure that there is an exclude rule in your antivirus for the Metasploit 
+directory (or that your antivirus is disabled).
+
+If the path to your metasploit framework repository is not `../metasploit-framework`,
+but for example `../msf3`, use
+
+```
+mvn -D deploy.path=../msf3 -P deploy package
+```
 
 In case you want to edit/debug JavaPayload for Metasploit or Java Meterpreter,
 Maven provides plugins to auto-generate project files for your favourite IDE
@@ -27,7 +34,7 @@ mvn eclipse:eclipse
 
 This will generate project files that can be imported via
 
-File->Import->Existing Projects into Workspace
+**File->Import->Existing Projects into Workspace**
 
 into your Eclipse workspace.
 

--- a/androidpayload/app/pom.xml
+++ b/androidpayload/app/pom.xml
@@ -7,6 +7,9 @@
 	<packaging>apk</packaging>
 	<name>AndroidPayload for Metasploit</name>
 
+	<properties>
+		<deploy.path>../metasploit-framework</deploy.path>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>com.google.android</groupId>
@@ -59,7 +62,7 @@
 								</goals>
 								<configuration>
 									<target>
-										<unzip src="${project.basedir}/target/${project.build.finalName}.apk" dest="${project.basedir}/../../../../../data/android/apk" >
+										<unzip src="${project.basedir}/target/${project.build.finalName}.apk" dest="${project.basedir}/../../${deploy.path}/data/android/apk" >
 											<patternset>
 												<exclude name="META-INF/**"/>
 											</patternset>

--- a/androidpayload/library/pom.xml
+++ b/androidpayload/library/pom.xml
@@ -7,6 +7,9 @@
 	<packaging>apk</packaging>
 	<name>Android Meterpreter</name>
 
+	<properties>
+		<deploy.path>../metasploit-framework</deploy.path>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>com.google.android</groupId>
@@ -92,7 +95,7 @@
 										<exec executable="${android.sdk.path}/platform-tools/${dx.filename}" failonerror="true">
 											<arg value="--verbose" />
 											<arg value="--dex" />
-											<arg value="--output=${project.basedir}/../../../../../data/android/shell.jar" />
+											<arg value="--output=${project.basedir}/../../${deploy.path}/data/android/shell.jar" />
 											<arg value="${project.basedir}/target/dx/shell" />
 										</exec>
 
@@ -107,7 +110,7 @@
 										<exec executable="${android.sdk.path}/platform-tools/${dx.filename}" failonerror="true">
 											<arg value="--verbose" />
 											<arg value="--dex" />
-											<arg value="--output=${project.basedir}/../../../../../data/android/metstage.jar" />
+											<arg value="--output=${project.basedir}/../../${deploy.path}/data/android/metstage.jar" />
 											<arg value="${project.basedir}/target/dx/metstage" />
 										</exec>
 
@@ -119,7 +122,7 @@
 										<exec executable="${android.sdk.path}/platform-tools/${dx.filename}" failonerror="true">
 											<arg value="--verbose" />
 											<arg value="--dex" />
-											<arg value="--output=${project.basedir}/../../../../../data/android/meterpreter.jar" />
+											<arg value="--output=${project.basedir}/../../${deploy.path}/data/android/meterpreter.jar" />
 											<arg value="${project.basedir}/target/dx/meterpreter" />
 											<arg value="${com.metasploit:Metasploit-Java-Meterpreter:jar}" />
 											<arg value="${com.metasploit:Metasploit-Java-Meterpreter-stdapi:jar}" />

--- a/javapayload/pom.xml
+++ b/javapayload/pom.xml
@@ -35,7 +35,7 @@
 								</goals>
 								<configuration>
 									<target>
-										<copy todir="${project.basedir}/../../../../data/java">
+										<copy todir="${project.basedir}/../${deploy.path}/data/java">
 											<fileset dir="${project.basedir}/target/classes">
 												<exclude name="metasploit/PayloadApplet.class" />
 												<exclude name="rmi/**" />

--- a/meterpreter/debugloader/pom.xml
+++ b/meterpreter/debugloader/pom.xml
@@ -28,31 +28,4 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
-	<profiles>
-		<profile>
-			<!-- deploy built files to Metasploit data directory -->
-			<id>deploy</id>
-			<build>
-				<plugins>
-					<plugin>
-						<artifactId>maven-antrun-plugin</artifactId>
-						<version>1.7</version>
-						<executions>
-							<execution>
-								<phase>package</phase>
-								<goals>
-									<goal>run</goal>
-								</goals>
-								<configuration>
-									<target>
-										<!-- TODO -->
-									</target>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
 </project>

--- a/meterpreter/meterpreter/pom.xml
+++ b/meterpreter/meterpreter/pom.xml
@@ -43,8 +43,8 @@
 										<touch datetime="01/01/2000 00:00 AM">
 											<fileset dir="${project.basedir}/target/tmp" includes="**/*" />
 										</touch>
-										<delete file="${project.basedir}/../../../../../data/meterpreter/${project.build.finalName}.jar"/>
-										<zip destfile="${project.basedir}/../../../../../data/meterpreter/${project.build.finalName}.jar">
+										<delete file="${project.basedir}/../../${deploy.path}/data/meterpreter/${project.build.finalName}.jar"/>
+										<zip destfile="${project.basedir}/../../${deploy.path}/data/meterpreter/${project.build.finalName}.jar">
 											<fileset dir="${project.basedir}/target/tmp" includes="META-INF/**" />
 											<fileset dir="${project.basedir}/target/tmp" excludes="META-INF/**" />
 										</zip>

--- a/meterpreter/stdapi/pom.xml
+++ b/meterpreter/stdapi/pom.xml
@@ -62,8 +62,8 @@
 										<touch datetime="01/01/2000 00:00 AM">
 											<fileset dir="${project.basedir}/target/tmp" includes="**/*" />
 										</touch>
-										<delete file="${project.basedir}/../../../../../data/meterpreter/${project.build.finalName}.jar"/>
-										<zip destfile="${project.basedir}/../../../../../data/meterpreter/${project.build.finalName}.jar">
+										<delete file="${project.basedir}/../../${deploy.path}/data/meterpreter/${project.build.finalName}.jar"/>
+										<zip destfile="${project.basedir}/../../${deploy.path}/data/meterpreter/${project.build.finalName}.jar">
 											<fileset dir="${project.basedir}/target/tmp" includes="META-INF/**" />
 											<fileset dir="${project.basedir}/target/tmp" excludes="META-INF/**" />
 										</zip>

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
 	<url>http://www.metasploit.com/</url>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<deploy.path>../metasploit-framework</deploy.path>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
As this repo it is no longer in external/source directory, the deploy
targets need to know where the Framework repository is. This defaults to
../metasploit-framework, but can be changed via -D deploy.path= command
line switch.
