### PR TITLE
Add getenv support to the Java payload

### DIFF
--- a/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVPacket.java
+++ b/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVPacket.java
@@ -39,9 +39,14 @@ public class TLVPacket {
 	private List/* <Integer> */typeOrder = new ArrayList();
 
 	/**
-	 * A map, mapping the types (as {@link Integer} objects) to values (different kinds of objects). There are type-safe helper methods to retrieve one of those objects from the map.
+	 * A list of objects that represent the values stored in the package.
 	 */
-	private Map/* <Integer,Object> */valueMap = new HashMap();
+	private List/* <Integer> */valueList = new ArrayList();
+
+	/**
+	 * A map, mapping the types (as {@link Integer} objects) to an {@link ArrayList} of {@link Integer} values that respresent the index into the valueList array.
+	 */
+	private Map/* <Integer,ArrayList> */valueMap = new HashMap();
 
 	/**
 	 * A list of additionals types/values to be added to the end of the packet. Here packet types may appear more than once, but they cannot be read again with this class.
@@ -58,11 +63,11 @@ public class TLVPacket {
 	 * Read a TLV packet from an input stream.
 	 * 
 	 * @param in
-	 *            Input stream to read from
+	 *						Input stream to read from
 	 * @param remaining
-	 *            length of the packet to read in bytes
+	 *						length of the packet to read in bytes
 	 * @throws IOException
-	 *             if an error occurs
+	 *						 if an error occurs
 	 */
 	public TLVPacket(DataInputStream in, int remaining) throws IOException {
 		while (remaining > 0) {
@@ -114,11 +119,22 @@ public class TLVPacket {
 	 * Add a TLV value to this object.
 	 */
 	public void add(int type, Object value) throws IOException {
+		ArrayList indices = null;
 		Integer typeObj = new Integer(type);
 		typeOrder.add(typeObj);
-		if (valueMap.containsKey(typeObj))
-			throw new IOException("Duplicate type: " + type);
-		valueMap.put(typeObj, value);
+
+		if (valueMap.containsKey(typeObj)) {
+			indices = (ArrayList)valueMap.get(typeObj);
+		} else {
+			indices = new ArrayList();
+			valueMap.put(typeObj, indices);
+		}
+
+		// add the index of the new element to the list of indices for the object
+		indices.add(new Integer(valueList.size()));
+
+		// add the value to the list of values that make up the object
+		valueList.add(value);
 	}
 
 	/**
@@ -154,20 +170,39 @@ public class TLVPacket {
 	 * Get the value associated to a type.
 	 */
 	public Object getValue(int type) {
-		Object result = valueMap.get(new Integer(type));
-		if (result == null)
+		ArrayList indices = (ArrayList)valueMap.get(new Integer(type));
+		if (indices == null)
 			throw new IllegalArgumentException("Cannot find type " + type);
-		return result;
+		// the indices variable is an ArrayList so by default return the first to
+		// preserve existing behaviour.
+		return valueList.get(((Integer)indices.get(0)).intValue());
+	}
+
+	/**
+	 * Get the list of values associated to a type.
+	 */
+	public List getValues(int type) {
+		ArrayList values = new ArrayList();
+		ArrayList indices = (ArrayList)valueMap.get(new Integer(type));
+		if (indices == null)
+			throw new IllegalArgumentException("Cannot find type " + type);
+
+		for (int i = 0; i < indices.size(); ++i) {
+			values.add(valueList.get(((Integer)indices.get(i)).intValue()));
+		}
+		return values;
 	}
 
 	/**
 	 * Get the value associated to a type.
 	 */
 	public Object getValue(int type, Object defaultValue) {
-		Object result = valueMap.get(new Integer(type));
-		if (result == null)
-			result = defaultValue;
-		return result;
+		ArrayList indices = (ArrayList)valueMap.get(new Integer(type));
+		if (indices == null)
+			return defaultValue;
+		// the indices variable is an ArrayList so by default return the first to
+		// preserve existing behaviour.
+		return valueList.get(((Integer)indices.get(0)).intValue());
 	}
 
 	/**
@@ -212,7 +247,7 @@ public class TLVPacket {
 		for (Iterator it = typeOrder.iterator(); it.hasNext();) {
 			Integer typeKey = (Integer) it.next();
 			int type = typeKey.intValue();
-			Object value = valueMap.get(typeKey);
+			Object value = getValue(type);
 			write(out, type, value);
 		}
 		for (Iterator it = overflowList.iterator(); it.hasNext();) {
@@ -224,7 +259,7 @@ public class TLVPacket {
 	}
 
 	/**
-	 * Write a single vlaue to an output stream.
+	 * Write a single value to an output stream.
 	 */
 	private static void write(DataOutputStream out, int type, Object value) throws IOException {
 		byte[] data;

--- a/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVPacket.java
+++ b/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVPacket.java
@@ -63,11 +63,11 @@ public class TLVPacket {
 	 * Read a TLV packet from an input stream.
 	 * 
 	 * @param in
-	 *						Input stream to read from
+	 *	Input stream to read from
 	 * @param remaining
-	 *						length of the packet to read in bytes
+	 *	length of the packet to read in bytes
 	 * @throws IOException
-	 *						 if an error occurs
+	 *	 if an error occurs
 	 */
 	public TLVPacket(DataInputStream in, int remaining) throws IOException {
 		while (remaining > 0) {

--- a/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVType.java
+++ b/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVType.java
@@ -105,6 +105,10 @@ public interface TLVType {
 	public static final int TLV_TYPE_OS_NAME = TLVPacket.TLV_META_TYPE_STRING | 1041;
 	public static final int TLV_TYPE_USER_NAME = TLVPacket.TLV_META_TYPE_STRING | 1042;
 
+	public static final int TLV_TYPE_ENV_VARIABLE = TLVPacket.TLV_META_TYPE_STRING | 1100;
+	public static final int TLV_TYPE_ENV_VALUE = TLVPacket.TLV_META_TYPE_STRING | 1101;
+	public static final int TLV_TYPE_ENV_GROUP = TLVPacket.TLV_META_TYPE_GROUP | 1102;
+
 	// Process
 	public static final int TLV_TYPE_BASE_ADDRESS = TLVPacket.TLV_META_TYPE_UINT | 2000;
 	public static final int TLV_TYPE_ALLOCATION_TYPE = TLVPacket.TLV_META_TYPE_UINT | 2001;

--- a/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/Loader.java
+++ b/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/Loader.java
@@ -43,6 +43,7 @@ public class Loader implements ExtensionLoader {
 		mgr.registerCommand("stdapi_net_config_get_routes", stdapi_net_config_get_routes.class, V1_4);
 		mgr.registerCommand("stdapi_net_socket_tcp_shutdown", stdapi_net_socket_tcp_shutdown.class, V1_2, V1_3);
 		mgr.registerCommand("stdapi_sys_config_getuid", stdapi_sys_config_getuid.class);
+		mgr.registerCommand("stdapi_sys_config_getenv", stdapi_sys_config_getenv.class);
 		mgr.registerCommand("stdapi_sys_config_sysinfo", stdapi_sys_config_sysinfo.class);
 		mgr.registerCommand("stdapi_sys_process_execute", stdapi_sys_process_execute.class, V1_2, V1_3);
 		mgr.registerCommand("stdapi_sys_process_get_processes", stdapi_sys_process_get_processes.class, V1_2);

--- a/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_config_getenv.java
+++ b/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_config_getenv.java
@@ -1,0 +1,36 @@
+package com.metasploit.meterpreter.stdapi;
+
+import com.metasploit.meterpreter.Meterpreter;
+import com.metasploit.meterpreter.TLVPacket;
+import com.metasploit.meterpreter.TLVType;
+import com.metasploit.meterpreter.command.Command;
+import java.util.List;
+
+public class stdapi_sys_config_getenv implements Command {
+	public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
+		List envVars = request.getValues(TLVType.TLV_TYPE_ENV_VARIABLE);
+
+		for (int i = 0; i < envVars.size(); ++i) {
+			String envVar = (String)envVars.get(i);
+
+			char c = envVar.charAt(0);
+			if (c == '$' || c == '%') {
+				envVar = envVar.substring(1);
+			}
+			c = envVar.charAt(envVar.length() - 1);
+			if (c == '$' || c == '%') {
+				envVar = envVar.substring(0, envVar.length() - 1);
+			}
+
+			String envVal = System.getenv(envVar);
+			TLVPacket grp = new TLVPacket();
+
+			grp.add(TLVType.TLV_TYPE_ENV_VARIABLE, envVar);
+			grp.add(TLVType.TLV_TYPE_ENV_VALUE, envVal);
+
+			response.addOverflow(TLVType.TLV_TYPE_ENV_GROUP, grp);
+		}
+
+		return ERROR_SUCCESS;
+	}
+}

--- a/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_config_getenv.java
+++ b/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_sys_config_getenv.java
@@ -13,12 +13,10 @@ public class stdapi_sys_config_getenv implements Command {
 		for (int i = 0; i < envVars.size(); ++i) {
 			String envVar = (String)envVars.get(i);
 
-			char c = envVar.charAt(0);
-			if (c == '$' || c == '%') {
+			if (envVar.startsWith("$") || envVar.startsWith("%")) {
 				envVar = envVar.substring(1);
 			}
-			c = envVar.charAt(envVar.length() - 1);
-			if (c == '$' || c == '%') {
+			if (envVar.endsWith("$") || envVar.endsWith("%")) {
 				envVar = envVar.substring(0, envVar.length() - 1);
 			}
 


### PR DESCRIPTION
This will bring this meterpreter in line with the other meterpreter payloads so that the getenv feature works consistently across them.

Here's a test run:

```
meterpreter > sysinfo
Computer    : ubuntu
OS          : Linux 3.11.0-18-generic (amd64)
Meterpreter : java/java
meterpreter > getenv $HOME %PATH% DISPLAY

Environment Variables
=====================

Variable  Value
--------  -----
HOME      /home/oj
PATH      /usr/lib/lightdm/lightdm:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
DISPLAY   :0
```

That experience was horrible. Yay for having to resort to substring hacks to get it to work.

## IMPORTANT

To get this working, I had to implement support for multiple Values of the same type. That is, `getenv` lets you pass in more than one value, and hence the same TLV type appears more than once in the payload. Java Meterpreter didn't like that at all. As a result I had to implement it. This is what I did:

* Added a container `ArrayList` which contained ALL the values that are pulled out of the packet.
* Changed the `valueMap` so that it contained `ArrayLists`s of _indices_ that represent the location of the values in the new list of packet values. This is stored for each type.
* To get access to a valid the index array for that type needs to be read and then the indices are used to look up the value list to get the value itself.
* The existing functionality was changed so that when someone asks for a value, they the first value in the array. This covers all the existing cases nicely.
* A new function called `getValues` was added which returns a list based on the type. This allows the caller to iterate through it themselves.

I hope that makes sense. I wanted to retain the existing functionality as much as possible.

Cheers!