### PR TITLE
Fix AndroidMeterpreter when running on Main thread

### DIFF
--- a/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
+++ b/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
@@ -49,6 +49,19 @@ public class AndroidMeterpreter extends Meterpreter {
     private static String writeableDir;
     private static Context context;
 
+    private void startExecutingOnThread() {
+        new Thread() {
+            @Override
+            public void run() {
+                try {
+                    startExecuting();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        }.start();
+    }
+
     private void findContext() throws Exception {
         final Class<?> activityThreadClass = Class.forName("android.app.ActivityThread");
         final Method currentApplication = activityThreadClass.getMethod("currentApplication");
@@ -63,11 +76,7 @@ public class AndroidMeterpreter extends Meterpreter {
                     } catch (Exception e) {
                         e.printStackTrace();
                     }
-                    try {
-                        startExecuting();
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
+                    startExecutingOnThread();
                 }
             });
         } else {


### PR DESCRIPTION
This should fix https://github.com/rapid7/metasploit-framework/issues/4920
From adb logcat:
```
W/System.err( 1423): android.os.NetworkOnMainThreadException
W/System.err( 1423):    at android.os.StrictMode$AndroidBlockGuardPolicy.onNetwork(StrictMode.java:1117)
W/System.err( 1423):    at libcore.io.BlockGuardOs.recvfrom(BlockGuardOs.java:163)
W/System.err( 1423):    at libcore.io.IoBridge.recvfrom(IoBridge.java:513)
W/System.err( 1423):    at java.net.PlainSocketImpl.read(PlainSocketImpl.java:488)
W/System.err( 1423):    at java.net.PlainSocketImpl.access$000(PlainSocketImpl.java:46)
W/System.err( 1423):    at java.net.PlainSocketImpl$PlainSocketInputStream.read(PlainSocketImpl.java:240)
W/System.err( 1423):    at libcore.io.Streams.readFully(Streams.java:81)
W/System.err( 1423):    at java.io.DataInputStream.readInt(DataInputStream.java:124)
W/System.err( 1423):    at com.metasploit.meterpreter.Meterpreter.startExecuting(Unknown Source)
W/System.err( 1423):    at com.metasploit.meterpreter.AndroidMeterpreter$1.run(AndroidMeterpreter.java:67)
W/System.err( 1423):    at android.os.Handler.handleCallback(Handler.java:615)
W/System.err( 1423):    at android.os.Handler.dispatchMessage(Handler.java:92)
W/System.err( 1423):    at android.os.Looper.loop(Looper.java:137)
W/System.err( 1423):    at android.app.ActivityThread.main(ActivityThread.java:4745)
W/System.err( 1423):    at java.lang.reflect.Method.invokeNative(Native Method)
W/System.err( 1423):    at java.lang.reflect.Method.invoke(Method.java:511)
W/System.err( 1423):    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:786)
W/System.err( 1423):    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:553)
W/System.err( 1423):    at dalvik.system.NativeStart.main(Native Method)
```
In some cases the thread that's loading meterpreter can't retrieve the Context object. To work around this we post to the Main/UI thread and try to find the Context again. After https://github.com/rapid7/metasploit-javapayload/pull/23 I forgot to switch the execution back to a background thread.