### PR TITLE
treat strings in TLV packets as UTF-8

### DIFF
--- a/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVPacket.java
+++ b/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVPacket.java
@@ -14,7 +14,7 @@ import java.util.Map;
 
 /**
  * A packet consisting of multiple TLV values. Having the same type more than once is an error.
- * 
+ *
  * @author mihi
  */
 public class TLVPacket {
@@ -62,7 +62,7 @@ public class TLVPacket {
 
 	/**
 	 * Read a TLV packet from an input stream.
-	 * 
+	 *
 	 * @param in
 	 *	Input stream to read from
 	 * @param remaining
@@ -84,7 +84,7 @@ public class TLVPacket {
 				value = data;
 			} else if ((type & TLV_META_TYPE_STRING) != 0) {
 				in.readFully(data);
-				String string = new String(data, "ISO-8859-1"); // better safe than sorry
+				String string = new String(data, "UTF-8");
 				if (!string.endsWith("\0"))
 					throw new IOException("C string is not 0 terminated: " + string);
 				string = string.substring(0, string.length() - 1);
@@ -281,7 +281,7 @@ public class TLVPacket {
 	private static void write(DataOutputStream out, int type, Object value) throws IOException {
 		byte[] data;
 		if ((type & TLV_META_TYPE_STRING) != 0) {
-			data = ((String) value + "\0").getBytes("ISO-8859-1");
+			data = ((String) value + "\0").getBytes("UTF-8");
 		} else if ((type & TLV_META_TYPE_QWORD) != 0) {
 			out.writeInt(16);
 			out.writeInt(type);


### PR DESCRIPTION
This modifies the TLV parser / packer in the Java meterpreter payload to treat strings to and from the metasploit framework as UTF-8 rather than ISO-8859-1 strings.

This fixes rapid7/metasploit-framework#4954

# Verification steps

* [ ] Java meterpreter should work as described in rapid7/metasploit-framework#4950
* [ ] it should pass the post/test/meterpreter module

```
msf post(meterpreter) > run

[*] Running against session 1
[*] Session type is meterpreter and platform is java/java
[*] Session doesn't implement getpid, skipping test
[+] should return a list of processes
[+] should return a user id
[+] should return a sysinfo Hash
[+] should return network interfaces
[+] should have an interface that matches session_host
[+] should return network routes
[+] should return the proper directory separator
[+] should return the current working directory
[+] should list files in the current directory
[+] should stat a directory
[+] should create and remove a dir
[+] should change directories
[+] should create and remove files
[+] should upload a file
[+] should do md5 and sha1 of files
[*] Passed: 15; Failed: 0
[*] Post module execution completed
```

* [ ] it should pass the post/test/file module (note - I think I found a preexisting issue here)
```
msf post(file) > run

[*] Running against session 1
[*] Session type is meterpreter and platform is java/java
[+] should test for file existence
[+] should test for directory existence
[+] should create text files
[+] should read the text we just wrote
[+] should append text files
[+] should delete text files
[-] FAILED: should move files
[-] Exception: Rex::Post::Meterpreter::RequestError : stdapi_fs_file_move: Operation failed: 1
[+] should write binary data
[+] should read the binary data we just wrote
[+] should delete binary files
[+] should append binary data
[*] Passed: 11; Failed: 0
[*] Post module execution completed
```