### PR TITLE
Fix a race condition in the shell unit test

### DIFF
--- a/javapayload/src/test/java/javapayload/stage/ShellTest.java
+++ b/javapayload/src/test/java/javapayload/stage/ShellTest.java
@@ -15,6 +15,11 @@ public class ShellTest extends TestCase {
 		DataInputStream in = new DataInputStream(new ByteArrayInputStream(commands.getBytes("ISO-8859-1")));
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		shell.start(in, out, new String[] {"Payload", "--", "Shell"});
+		int timeout = 5000;
+		while (out.size() == 0 && timeout > 0) {
+			Thread.sleep(100);
+			timeout -= 100;
+		}
 		String shellOutput = new String(out.toByteArray(), "ISO-8859-1");
 		Assert.assertTrue("MagicToken missing in shell output: "+shellOutput, shellOutput.contains("MagicToken"));
 		Assert.assertEquals(-1, in.read());


### PR DESCRIPTION
The shell unit test was failing for me randomly, more often on my test build machine than on my laptop. I tracked it down to a missing bit of synchronization between starting a shell command and checking the output.

This change waits up to 5 seconds for shell output before checking the result. I have not had a failure since. I'm sure there is a more elegant way to wait for the ready condition, but I tried a few other more complex things that had inconsistent results.

# Verification

Run 'mvn package' on a relatively fast machine and observe that the build always succeeds. This is a bit of a heisenbug. If you never had the issue before this change, you should at least continue not seeing it.