### PR TITLE
Add TLV_TYPE_FILE_HASH

### DIFF
--- a/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVPacket.java
+++ b/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVPacket.java
@@ -14,7 +14,7 @@ import java.util.Map;
 
 /**
  * A packet consisting of multiple TLV values. Having the same type more than once is an error.
- * 
+ *
  * @author mihi
  */
 public class TLVPacket {
@@ -62,7 +62,7 @@ public class TLVPacket {
 
 	/**
 	 * Read a TLV packet from an input stream.
-	 * 
+	 *
 	 * @param in
 	 *	Input stream to read from
 	 * @param remaining
@@ -84,7 +84,7 @@ public class TLVPacket {
 				value = data;
 			} else if ((type & TLV_META_TYPE_STRING) != 0) {
 				in.readFully(data);
-				String string = new String(data, "ISO-8859-1"); // better safe than sorry
+				String string = new String(data, "UTF-8");
 				if (!string.endsWith("\0"))
 					throw new IOException("C string is not 0 terminated: " + string);
 				string = string.substring(0, string.length() - 1);
@@ -281,7 +281,7 @@ public class TLVPacket {
 	private static void write(DataOutputStream out, int type, Object value) throws IOException {
 		byte[] data;
 		if ((type & TLV_META_TYPE_STRING) != 0) {
-			data = ((String) value + "\0").getBytes("ISO-8859-1");
+			data = ((String) value + "\0").getBytes("UTF-8");
 		} else if ((type & TLV_META_TYPE_QWORD) != 0) {
 			out.writeInt(16);
 			out.writeInt(type);

--- a/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVType.java
+++ b/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVType.java
@@ -57,6 +57,7 @@ public interface TLVType {
 	public static final int TLV_TYPE_FILE_NAME = TLVPacket.TLV_META_TYPE_STRING | 1201;
 	public static final int TLV_TYPE_FILE_PATH = TLVPacket.TLV_META_TYPE_STRING | 1202;
 	public static final int TLV_TYPE_FILE_MODE = TLVPacket.TLV_META_TYPE_STRING | 1203;
+	public static final int TLV_TYPE_FILE_HASH = TLVPacket.TLV_META_TYPE_RAW | 1206;
 	public static final int TLV_TYPE_STAT_BUF = TLVPacket.TLV_META_TYPE_COMPLEX | 1220;
 
 	// Net

--- a/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/HashCommand.java
+++ b/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/HashCommand.java
@@ -20,7 +20,7 @@ public abstract class HashCommand implements Command {
 		while ((len = in.read(buf)) != -1) {
 			md.update(buf, 0, len);
 		}
-		response.add(TLVType.TLV_TYPE_FILE_NAME, new String(md.digest(), "ISO-8859-1"));
+		response.add(TLVType.TLV_TYPE_FILE_HASH, md.digest());
 		return ERROR_SUCCESS;
 	}
 }


### PR DESCRIPTION
This change adds a TLV_TYPE_FILE_HASH type.
This should allow both the post/test/meterpreter module to pass, and add support for UTF-8 filenames.