### PR TITLE
fix race condition

### DIFF
--- a/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
+++ b/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java
@@ -68,18 +68,20 @@ public class AndroidMeterpreter extends Meterpreter {
             final Handler handler = new Handler(Looper.getMainLooper());
             handler.post(new Runnable() {
                 public void run() {
-                    try {
-                        context = (Context) currentApplication.invoke(null, (Object[]) null);
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
                     synchronized (contextWaiter) {
+                        try {
+                            context = (Context) currentApplication.invoke(null, (Object[]) null);
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        }
                         contextWaiter.notify();
                     }
                 }
             });
             synchronized (contextWaiter) {
-                contextWaiter.wait();
+                if (context == null) {
+                    contextWaiter.wait(100);
+                }
             }
         }
     }


### PR DESCRIPTION
This change fixes a race condition when switching between the execution and UI thread. On some devices the notify was called before the execution thread began waiting. This change ensures the thread only waits if the context has not been found.
Fixes https://github.com/rapid7/metasploit-framework/pull/5366