### PR TITLE
Added SuperSU.apk to check_root

### DIFF
--- a/androidpayload/library/src/com/metasploit/meterpreter/android/check_root_android.java
+++ b/androidpayload/library/src/com/metasploit/meterpreter/android/check_root_android.java
@@ -33,6 +33,12 @@ public class check_root_android implements Command {
                 return true;
             }
 
+	    //Added check for SuperSU
+            file = new File("/system/app/SuperSU.apk");
+            if (file.exists()) {
+                return true;
+            }
+
         } catch (Exception e1) {
 
         }


### PR DESCRIPTION
Just added a simple check for /system/app/SuperSU.apk to the android check_root meterpreter function.