### PR TITLE
update to android API level 10

### DIFF
--- a/androidpayload/app/pom.xml
+++ b/androidpayload/app/pom.xml
@@ -26,7 +26,7 @@
 				<plugin>
 					<groupId>com.jayway.maven.plugins.android.generation2</groupId>
 					<artifactId>android-maven-plugin</artifactId>
-					<version>3.5.3</version>
+					<version>3.7.0</version>
 
 					<extensions>true</extensions>
 				</plugin>
@@ -38,8 +38,8 @@
 				<artifactId>android-maven-plugin</artifactId>
 				<configuration>
 					<sdk>
-						<!-- platform or api level (api level 4 = platform 1.6)-->
-						<platform>3</platform>
+						<!-- platform or api level (api level 10 = platform 2.3)-->
+						<platform>10</platform>
 					</sdk>
 				</configuration>
 			</plugin>

--- a/androidpayload/library/pom.xml
+++ b/androidpayload/library/pom.xml
@@ -47,7 +47,7 @@
 				<plugin>
 					<groupId>com.jayway.maven.plugins.android.generation2</groupId>
 					<artifactId>android-maven-plugin</artifactId>
-					<version>3.5.3</version>
+					<version>3.7.0</version>
 
 					<extensions>true</extensions>
 				</plugin>
@@ -59,8 +59,8 @@
 				<artifactId>android-maven-plugin</artifactId>
 				<configuration>
 					<sdk>
-						<!-- platform or api level (api level 4 = platform 1.6)-->
-						<platform>3</platform>
+						<!-- platform or api level (api level 10 = platform 2.3)-->
+						<platform>10</platform>
 					</sdk>
 				</configuration>
 			</plugin>

--- a/version-compatibility-check/android-api10/pom.xml
+++ b/version-compatibility-check/android-api10/pom.xml
@@ -2,14 +2,14 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.metasploit</groupId>
-	<artifactId>Metasploit-JavaPayload-Compatibility-android-api3</artifactId>
+	<artifactId>Metasploit-JavaPayload-Compatibility-android-api10</artifactId>
 	<parent>
 		<groupId>com.metasploit</groupId>
 		<artifactId>Metasploit-JavaPayload-Compatibility-parent</artifactId>
 		<version>1-SNAPSHOT</version>
 	</parent>
 	<packaging>jar</packaging>
-	<name>JavaPayload Compatibility Checks (Android API 3)</name>
+	<name>JavaPayload Compatibility Checks (Android API 10)</name>
 	<url>http://www.metasploit.com/</url>
 	<dependencies>
 		<dependency>
@@ -72,8 +72,8 @@
 						<configuration>
 							<signature>
 								<groupId>net.sf.androidscents.signature</groupId>
-								<artifactId>android-api-level-1</artifactId>
-								<version>1.0_r2</version>
+								<artifactId>android-api-level-10</artifactId>
+								<version>2.3.3_r2</version>
 							</signature>
 						</configuration>
 					</execution>

--- a/version-compatibility-check/pom.xml
+++ b/version-compatibility-check/pom.xml
@@ -54,6 +54,6 @@
 		<module>java14</module>
 		<module>java13</module>
 		<module>java12</module>
-		<module>android-api3</module>
+		<module>android-api10</module>
 	</modules>
 </project>


### PR DESCRIPTION
This PR upgrades our default API level for Android builds to 10, which is the Gingerbread release. This removes support for pre-2.3 Android images, but does make accessing newer Android APIs easier as well as potentially allowing using newer Java APIs. Only about 1-2% of Android phones still in use today appear to be using older versions  than this (https://developer.android.com/about/dashboards/index.html?utm_source=suzunone)

# Verification Steps

To verify it, simply confirm that metasploit-javapayloads continues to build and run.

I chose a version of android-maven-plugin that supports Android API 10, but still works on Maven 3.0.x. Note that this plugin has moved to a different repository for contemporary revisions.