### PR TITLE
Remove old java versions, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ http://maven.apache.org/plugins/maven-idea-plugin/
 
 1. Download the [Android SDK](https://developer.android.com/sdk/index.html), and the [Android NDK](https://developer.android.com/tools/sdk/ndk/index.html) somewhere
 2. Launch the `sdk/tool/android` program
-3. Install API version 3, and update the "Android SDK Tools" and "Android SDK Platform-tools"
+3. Install API version 10, and update the "Android SDK Tools" and "Android SDK Platform-tools"
 4. Compile android meterpreter:
 
 ```

--- a/version-compatibility-check/pom.xml
+++ b/version-compatibility-check/pom.xml
@@ -52,8 +52,6 @@
 		<module>java16</module>
 		<module>java15</module>
 		<module>java14</module>
-		<module>java13</module>
-		<module>java12</module>
 		<module>android-api10</module>
 	</modules>
 </project>


### PR DESCRIPTION
Remove Java 1.2 and 1.3 from the compatibility checks now that we are at API 10. Also updated the README to say that API 10 is required, not 3.